### PR TITLE
Bump to 0.3.0; update installation docs to use GDS IDEA package index

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,16 +25,32 @@ You need access to the `co-cddo` GitHub organisation.
 
 ## Installation
 
-`idea-gh` is installed as a global CLI tool:
+`idea-gh` is installed as a global CLI tool via the [GDS IDEA package index](https://co-cddo.github.io/gds-idea-pypi/).
+
+**Recommended — using `idea-tools`** (see the [index page](https://co-cddo.github.io/gds-idea-pypi/) for one-time setup):
 
 ```bash
-uv tool install "gds-idea-gh-kit @ git+https://github.com/co-cddo/gds-idea-gh-kit"
+idea-tools install gds-idea-gh-kit
+```
+
+**Alternative — without `idea-tools`:**
+
+```bash
+uv tool install gds-idea-gh-kit --index gds-idea=https://co-cddo.github.io/gds-idea-pypi/simple/
 ```
 
 To upgrade to the latest version:
 
 ```bash
+idea-tools upgrade gds-idea-gh-kit
+# or without idea-tools:
 uv tool upgrade gds-idea-gh-kit
+```
+
+If you previously installed from a git URL, switch to the index:
+
+```bash
+idea-tools install gds-idea-gh-kit --reinstall
 ```
 
 Verify it's working:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gds-idea-gh-kit"
-version = "0.2.6"
+version = "0.3.0"
 description = "CLI tool for auditing and enforcing GitHub repo standards for GDS IDEA teams"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
## Summary

- Bumps version to 0.3.0 to mark the switch to the GDS IDEA package index as the distribution method
- Updates installation instructions to use `idea-tools install` (recommended) or `uv tool install --index gds-idea=URL` instead of the git URL
- Adds upgrade and migration instructions aligned with the [GDS IDEA Package Index](https://co-cddo.github.io/gds-idea-pypi/)