### PR TITLE
feat: add per-branch merge method enforcement and version currency check

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -13,7 +13,7 @@ teams:
 repo_settings:
   delete_branch_on_merge: true
   allow_squash_merge: true
-  allow_merge_commit: false
+  allow_merge_commit: true
   allow_rebase_merge: false
   has_issues: true
   has_wiki: false
@@ -46,14 +46,17 @@ repo_types:
         prevent_force_push: true
         bypass_teams: [gds-idea-super-admin]
         bypass_mode: pull_request
+        allowed_merge_methods: [squash]
       prod:
         require_pr: true
         required_approvals: 1
+        dismiss_stale_reviews: true
         required_review_teams: [gds-idea-senior-ds]
         prevent_deletion: true
         prevent_force_push: true
         bypass_teams: []
         bypass_mode: pull_request
+        allowed_merge_methods: [merge]
 
   python-package:
     naming_pattern: "gds-idea-{name}"
@@ -71,3 +74,4 @@ repo_types:
         prevent_force_push: true
         bypass_teams: [gds-idea-super-admin]
         bypass_mode: pull_request
+        allowed_merge_methods: [squash]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gds-idea-gh-kit"
-version = "0.3.0"
+version = "0.3.1"
 description = "CLI tool for auditing and enforcing GitHub repo standards for GDS IDEA teams"
 readme = "README.md"
 authors = [

--- a/src/gds_idea_gh_kit/checks/branches.py
+++ b/src/gds_idea_gh_kit/checks/branches.py
@@ -222,6 +222,31 @@ def _audit_ruleset(
                     )
                 )
 
+            # Allowed merge methods
+            if expected.allowed_merge_methods:
+                actual_methods = sorted(params.get("allowed_merge_methods", []))
+                expected_methods = sorted(expected.allowed_merge_methods)
+                if actual_methods == expected_methods:
+                    results.append(
+                        CheckResult(
+                            name=f"branches.ruleset.{branch}.merge_methods",
+                            status=CheckStatus.PASSED,
+                            message=f"Branch '{branch}': allowed merge methods: {actual_methods}",
+                        )
+                    )
+                else:
+                    results.append(
+                        CheckResult(
+                            name=f"branches.ruleset.{branch}.merge_methods",
+                            status=CheckStatus.FAILED,
+                            message=(
+                                f"Branch '{branch}': allowed merge methods: {actual_methods} "
+                                f"(expected {expected_methods})"
+                            ),
+                            fix_available=True,
+                        )
+                    )
+
     # --- Bypass actors ---
     actual_bypass = ruleset.get("bypass_actors", [])
     actual_bypass_team_ids = {a["actor_id"] for a in actual_bypass if a.get("actor_type") == "Team"}
@@ -355,6 +380,8 @@ def build_ruleset_payload(
             "require_last_push_approval": False,
             "required_review_thread_resolution": False,
         }
+        if bp.allowed_merge_methods:
+            pr_params["allowed_merge_methods"] = bp.allowed_merge_methods
         rules.append({"type": "pull_request", "parameters": pr_params})
 
     # Bypass actors

--- a/src/gds_idea_gh_kit/cli.py
+++ b/src/gds_idea_gh_kit/cli.py
@@ -68,6 +68,10 @@ def audit(ctx: click.Context, repo_type: str | None, audit_all: bool, apply_fix:
     from gds_idea_gh_kit.config import ConfigError, load_config
     from gds_idea_gh_kit.github_client import AuthError, GitHubClient, GitHubClientError
     from gds_idea_gh_kit.repo_info import RepoInfoError, get_repo_from_remote
+    from gds_idea_gh_kit.version import check_tool_is_current
+
+    # -- Check tool is current --
+    check_tool_is_current()
 
     try:
         config = load_config(ctx.obj["config_path"])
@@ -284,6 +288,10 @@ def init(ctx: click.Context, repo_type: str):
     from gds_idea_gh_kit.config import ConfigError, load_config
     from gds_idea_gh_kit.github_client import AuthError, GitHubClient, GitHubClientError
     from gds_idea_gh_kit.init import InitError, get_repo_name_from_directory, init_repo
+    from gds_idea_gh_kit.version import check_tool_is_current
+
+    # -- Check tool is current --
+    check_tool_is_current()
 
     try:
         config = load_config(ctx.obj["config_path"])

--- a/src/gds_idea_gh_kit/config.yml
+++ b/src/gds_idea_gh_kit/config.yml
@@ -13,7 +13,7 @@ teams:
 repo_settings:
   delete_branch_on_merge: true
   allow_squash_merge: true
-  allow_merge_commit: false
+  allow_merge_commit: true
   allow_rebase_merge: false
   has_issues: true
   has_wiki: false
@@ -47,14 +47,17 @@ repo_types:
         prevent_force_push: true
         bypass_teams: [gds-idea-super-admin]
         bypass_mode: pull_request
+        allowed_merge_methods: [squash]
       prod:
         require_pr: true
         required_approvals: 1
+        dismiss_stale_reviews: true
         required_review_teams: [gds-idea-senior-ds]
         prevent_deletion: true
         prevent_force_push: true
         bypass_teams: []
         bypass_mode: pull_request
+        allowed_merge_methods: [merge]
 
   python-package:
     naming_pattern: "gds-idea-{name}"
@@ -72,3 +75,4 @@ repo_types:
         prevent_force_push: true
         bypass_teams: [gds-idea-super-admin]
         bypass_mode: pull_request
+        allowed_merge_methods: [squash]

--- a/src/gds_idea_gh_kit/models.py
+++ b/src/gds_idea_gh_kit/models.py
@@ -101,12 +101,24 @@ class BranchProtectionConfig(BaseModel):
     """Teams that can bypass rules on this branch (by slug)."""
     bypass_mode: str = "pull_request"
     """When bypass teams can bypass: 'always' or 'pull_request'."""
+    allowed_merge_methods: list[str] = Field(default_factory=list)
+    """Merge methods allowed for PRs targeting this branch (e.g. ['squash', 'merge']).
+    Empty list means no restriction (all repo-level methods allowed)."""
 
     @field_validator("bypass_mode")
     @classmethod
     def bypass_mode_must_be_valid(cls, v: str) -> str:
         if v not in ("always", "pull_request"):
             raise ValueError(f"bypass_mode must be 'always' or 'pull_request', got '{v}'")
+        return v
+
+    @field_validator("allowed_merge_methods")
+    @classmethod
+    def merge_methods_must_be_valid(cls, v: list[str]) -> list[str]:
+        valid = {"merge", "squash", "rebase"}
+        for method in v:
+            if method not in valid:
+                raise ValueError(f"Invalid merge method '{method}'. Must be one of: {', '.join(sorted(valid))}")
         return v
 
 

--- a/src/gds_idea_gh_kit/version.py
+++ b/src/gds_idea_gh_kit/version.py
@@ -1,0 +1,100 @@
+"""Version currency check for the gds-idea-gh-kit CLI.
+
+Provides functions to fetch the latest published version from the internal
+PyPI index and prompt the user to upgrade if a newer version is available.
+"""
+
+import re
+import sys
+import urllib.error
+import urllib.request
+
+import click
+
+from gds_idea_gh_kit import __version__
+
+_GDS_IDEA_INDEX_URL = "https://co-cddo.github.io/gds-idea-pypi/simple/"
+
+
+def _parse_version(version: str) -> tuple[int, ...]:
+    """Parse a dotted version string into a tuple of integers for comparison.
+
+    Args:
+        version: A dotted version string (e.g. "0.1.0").
+
+    Returns:
+        Tuple of integers (e.g. (0, 1, 0)).
+    """
+    return tuple(int(x) for x in version.split("."))
+
+
+def _fetch_latest_version(timeout: int = 3) -> str | None:
+    """Fetch the latest published version of gds-idea-gh-kit from the internal PyPI index.
+
+    Returns None silently if the network is unavailable or the response cannot be parsed.
+
+    Args:
+        timeout: Request timeout in seconds.
+
+    Returns:
+        Latest version string (e.g. "0.3.1"), or None on any error.
+    """
+    url = f"{_GDS_IDEA_INDEX_URL}gds-idea-gh-kit/"
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as response:  # noqa: S310
+            html = response.read().decode("utf-8", errors="replace")
+    except (urllib.error.URLError, OSError):
+        return None
+
+    # PEP 503 simple index: links look like gds_idea_gh_kit-0.3.1-py3-none-any.whl
+    versions = re.findall(r"gds[_-]idea[_-]gh[_-]kit-(\d+\.\d+(?:\.\d+)?)", html)
+    if not versions:
+        return None
+
+    try:
+        return max(versions, key=_parse_version)
+    except (ValueError, TypeError):
+        return None
+
+
+def check_tool_is_current() -> None:
+    """Check whether the installed tool is the latest available version.
+
+    Fetches the latest version from the internal PyPI index and compares it
+    against the currently installed version. If a newer version is available,
+    prints a warning to stderr with upgrade instructions and prompts the user
+    to confirm whether to continue. Defaults to No (exit) to encourage upgrading.
+
+    Does nothing if the network is unavailable or the version cannot be fetched.
+    """
+    latest = _fetch_latest_version()
+    if latest is None:
+        return
+
+    try:
+        if _parse_version(latest) <= _parse_version(__version__):
+            return
+    except (ValueError, TypeError):
+        return
+
+    click.echo(
+        f"Warning: gds-idea-gh-kit {latest} is available (you have {__version__}).",
+        err=True,
+    )
+    click.echo("", err=True)
+    click.echo("To upgrade:", err=True)
+    click.echo("  idea-tools upgrade gds-idea-gh-kit", err=True)
+    click.echo("    (if you have idea-tools set up)", err=True)
+    click.echo("", err=True)
+    click.echo("    OR", err=True)
+    click.echo("", err=True)
+    click.echo(
+        f'  uv tool upgrade gds-idea-gh-kit --index "gds-idea={_GDS_IDEA_INDEX_URL}"',
+        err=True,
+    )
+    click.echo("", err=True)
+
+    if not click.confirm("Continue with the current version?", default=False, err=True):
+        sys.exit(0)
+
+    click.echo("", err=True)

--- a/tests/test_checks/test_branches.py
+++ b/tests/test_checks/test_branches.py
@@ -526,3 +526,159 @@ def test_fix_no_stale_when_default_already_correct(httpx_mock: HTTPXMock, gh_cli
     changes, stale_branches = branches.fix("co-cddo", "my-repo", type_config, gh_client)
 
     assert len(stale_branches) == 0
+
+
+# --- Allowed merge methods ---
+
+
+def _full_rules_with_merge_methods(
+    approvals=1,
+    dismiss_stale=True,
+    allowed_merge_methods=None,
+):
+    """Build rules including allowed_merge_methods in PR params."""
+    pr_params = {
+        "required_approving_review_count": approvals,
+        "dismiss_stale_reviews_on_push": dismiss_stale,
+    }
+    if allowed_merge_methods is not None:
+        pr_params["allowed_merge_methods"] = allowed_merge_methods
+    return [
+        {"type": "deletion"},
+        {"type": "non_fast_forward"},
+        {"type": "required_linear_history"},
+        {"type": "pull_request", "parameters": pr_params},
+    ]
+
+
+def test_allowed_merge_methods_pass(httpx_mock: HTTPXMock, gh_client: GitHubClient):
+    """Passes when actual merge methods match expected."""
+    httpx_mock.add_response(
+        url="https://api.github.com/repos/co-cddo/my-repo",
+        json={"default_branch": "dev"},
+    )
+    httpx_mock.add_response(
+        url="https://api.github.com/repos/co-cddo/my-repo/branches/dev/protection",
+        status_code=404,
+    )
+    httpx_mock.add_response(
+        url="https://api.github.com/repos/co-cddo/my-repo/rulesets",
+        json=[{"id": 42, "name": "idea-gh: dev"}],
+    )
+    httpx_mock.add_response(
+        url="https://api.github.com/repos/co-cddo/my-repo/rulesets/42",
+        json=_make_ruleset_response(
+            rules=_full_rules_with_merge_methods(allowed_merge_methods=["squash"]),
+        ),
+    )
+
+    type_config = RepoTypeConfig(
+        naming_pattern="gds-idea-app-{name}",
+        default_branch="dev",
+        branch_protection={
+            "dev": BranchProtectionConfig(
+                require_linear_history=True,
+                allowed_merge_methods=["squash"],
+            )
+        },
+    )
+    results = branches.audit("co-cddo", "my-repo", type_config, gh_client)
+    merge_results = [r for r in results if "merge_methods" in r.name]
+    assert len(merge_results) == 1
+    assert merge_results[0].status == CheckStatus.PASSED
+
+
+def test_allowed_merge_methods_fail(httpx_mock: HTTPXMock, gh_client: GitHubClient):
+    """Fails when actual merge methods don't match expected."""
+    httpx_mock.add_response(
+        url="https://api.github.com/repos/co-cddo/my-repo",
+        json={"default_branch": "dev"},
+    )
+    httpx_mock.add_response(
+        url="https://api.github.com/repos/co-cddo/my-repo/branches/dev/protection",
+        status_code=404,
+    )
+    httpx_mock.add_response(
+        url="https://api.github.com/repos/co-cddo/my-repo/rulesets",
+        json=[{"id": 42, "name": "idea-gh: dev"}],
+    )
+    httpx_mock.add_response(
+        url="https://api.github.com/repos/co-cddo/my-repo/rulesets/42",
+        json=_make_ruleset_response(
+            rules=_full_rules_with_merge_methods(
+                allowed_merge_methods=["merge", "squash", "rebase"],
+            ),
+        ),
+    )
+
+    type_config = RepoTypeConfig(
+        naming_pattern="gds-idea-app-{name}",
+        default_branch="dev",
+        branch_protection={
+            "dev": BranchProtectionConfig(
+                require_linear_history=True,
+                allowed_merge_methods=["squash"],
+            )
+        },
+    )
+    results = branches.audit("co-cddo", "my-repo", type_config, gh_client)
+    merge_results = [r for r in results if "merge_methods" in r.name]
+    assert len(merge_results) == 1
+    assert merge_results[0].status == CheckStatus.FAILED
+    assert merge_results[0].fix_available is True
+
+
+def test_allowed_merge_methods_not_configured_skips(httpx_mock: HTTPXMock, gh_client: GitHubClient):
+    """No merge_methods check when config has empty list."""
+    httpx_mock.add_response(
+        url="https://api.github.com/repos/co-cddo/my-repo",
+        json={"default_branch": "dev"},
+    )
+    httpx_mock.add_response(
+        url="https://api.github.com/repos/co-cddo/my-repo/branches/dev/protection",
+        status_code=404,
+    )
+    httpx_mock.add_response(
+        url="https://api.github.com/repos/co-cddo/my-repo/rulesets",
+        json=[{"id": 42, "name": "idea-gh: dev"}],
+    )
+    httpx_mock.add_response(
+        url="https://api.github.com/repos/co-cddo/my-repo/rulesets/42",
+        json=_make_ruleset_response(rules=_full_rules()),
+    )
+
+    type_config = RepoTypeConfig(
+        naming_pattern="gds-idea-app-{name}",
+        default_branch="dev",
+        branch_protection={
+            "dev": BranchProtectionConfig(
+                require_linear_history=True,
+                allowed_merge_methods=[],
+            )
+        },
+    )
+    results = branches.audit("co-cddo", "my-repo", type_config, gh_client)
+    merge_results = [r for r in results if "merge_methods" in r.name]
+    assert len(merge_results) == 0
+
+
+def test_build_ruleset_payload_includes_allowed_merge_methods(gh_client: GitHubClient):
+    """Payload includes allowed_merge_methods when configured."""
+    bp = BranchProtectionConfig(
+        require_pr=True,
+        allowed_merge_methods=["squash"],
+    )
+    payload = branches.build_ruleset_payload("idea-gh: dev", "dev", bp, "co-cddo", gh_client)
+    pr_rule = [r for r in payload["rules"] if r["type"] == "pull_request"][0]
+    assert pr_rule["parameters"]["allowed_merge_methods"] == ["squash"]
+
+
+def test_build_ruleset_payload_omits_merge_methods_when_empty(gh_client: GitHubClient):
+    """Payload omits allowed_merge_methods when config list is empty."""
+    bp = BranchProtectionConfig(
+        require_pr=True,
+        allowed_merge_methods=[],
+    )
+    payload = branches.build_ruleset_payload("idea-gh: dev", "dev", bp, "co-cddo", gh_client)
+    pr_rule = [r for r in payload["rules"] if r["type"] == "pull_request"][0]
+    assert "allowed_merge_methods" not in pr_rule["parameters"]

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,149 @@
+"""Tests for the version currency check."""
+
+import urllib.error
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from gds_idea_gh_kit.version import _fetch_latest_version, check_tool_is_current
+
+# ---- _fetch_latest_version ----
+
+_SIMPLE_INDEX_HTML = b"""
+<!DOCTYPE html>
+<html>
+  <body>
+    <a href="gds_idea_gh_kit-0.2.0-py3-none-any.whl">gds_idea_gh_kit-0.2.0-py3-none-any.whl</a>
+    <a href="gds_idea_gh_kit-0.3.0-py3-none-any.whl">gds_idea_gh_kit-0.3.0-py3-none-any.whl</a>
+    <a href="gds_idea_gh_kit-0.3.1-py3-none-any.whl">gds_idea_gh_kit-0.3.1-py3-none-any.whl</a>
+  </body>
+</html>
+"""
+
+
+def _mock_urlopen(html: bytes = _SIMPLE_INDEX_HTML):
+    """Return a context-manager mock that yields a response with the given HTML."""
+    mock_response = MagicMock()
+    mock_response.read.return_value = html
+    mock_response.__enter__ = lambda s: s
+    mock_response.__exit__ = MagicMock(return_value=False)
+    return mock_response
+
+
+def test_fetch_latest_version_returns_highest():
+    """Returns the highest version found in the index HTML."""
+    with patch("urllib.request.urlopen", return_value=_mock_urlopen()):
+        result = _fetch_latest_version()
+    assert result == "0.3.1"
+
+
+def test_fetch_latest_version_single_entry():
+    """Works when only one version is listed."""
+    html = b'<a href="gds_idea_gh_kit-0.2.0-py3-none-any.whl">gds_idea_gh_kit-0.2.0</a>'
+    with patch("urllib.request.urlopen", return_value=_mock_urlopen(html)):
+        result = _fetch_latest_version()
+    assert result == "0.2.0"
+
+
+def test_fetch_latest_version_network_error_returns_none():
+    """Returns None silently when the network is unavailable."""
+    with patch("urllib.request.urlopen", side_effect=urllib.error.URLError("unreachable")):
+        result = _fetch_latest_version()
+    assert result is None
+
+
+def test_fetch_latest_version_os_error_returns_none():
+    """Returns None silently on a generic OS/socket error."""
+    with patch("urllib.request.urlopen", side_effect=OSError("timeout")):
+        result = _fetch_latest_version()
+    assert result is None
+
+
+def test_fetch_latest_version_empty_html_returns_none():
+    """Returns None when the response contains no recognisable version links."""
+    with patch("urllib.request.urlopen", return_value=_mock_urlopen(b"<html></html>")):
+        result = _fetch_latest_version()
+    assert result is None
+
+
+# ---- check_tool_is_current ----
+
+
+def test_check_tool_is_current_no_output_when_up_to_date(capsys):
+    """Prints nothing when the installed version matches the latest."""
+    with (
+        patch("gds_idea_gh_kit.version.__version__", "0.3.1"),
+        patch("gds_idea_gh_kit.version._fetch_latest_version", return_value="0.3.1"),
+    ):
+        check_tool_is_current()
+
+    assert capsys.readouterr().err == ""
+
+
+def test_check_tool_is_current_no_output_when_ahead(capsys):
+    """Prints nothing when the installed version is newer than the index."""
+    with (
+        patch("gds_idea_gh_kit.version.__version__", "0.4.0"),
+        patch("gds_idea_gh_kit.version._fetch_latest_version", return_value="0.3.1"),
+    ):
+        check_tool_is_current()
+
+    assert capsys.readouterr().err == ""
+
+
+def test_check_tool_is_current_no_output_when_fetch_fails(capsys):
+    """Prints nothing when the version fetch returns None."""
+    with patch("gds_idea_gh_kit.version._fetch_latest_version", return_value=None):
+        check_tool_is_current()
+
+    assert capsys.readouterr().err == ""
+
+
+def test_check_tool_is_current_warns_when_outdated(capsys):
+    """Prints the new version number to stderr when outdated."""
+    with (
+        patch("gds_idea_gh_kit.version.__version__", "0.3.0"),
+        patch("gds_idea_gh_kit.version._fetch_latest_version", return_value="0.3.1"),
+        patch("click.confirm", return_value=True),
+    ):
+        check_tool_is_current()
+
+    assert "0.3.1" in capsys.readouterr().err
+
+
+def test_check_tool_is_current_shows_upgrade_commands(capsys):
+    """The warning includes both upgrade commands."""
+    with (
+        patch("gds_idea_gh_kit.version.__version__", "0.3.0"),
+        patch("gds_idea_gh_kit.version._fetch_latest_version", return_value="0.3.1"),
+        patch("click.confirm", return_value=True),
+    ):
+        check_tool_is_current()
+
+    err = capsys.readouterr().err
+    assert "idea-tools upgrade gds-idea-gh-kit" in err
+    assert "uv tool upgrade gds-idea-gh-kit" in err
+    assert "OR" in err
+
+
+def test_check_tool_is_current_exits_when_user_declines():
+    """Exits cleanly when the user answers No."""
+    with (
+        patch("gds_idea_gh_kit.version.__version__", "0.3.0"),
+        patch("gds_idea_gh_kit.version._fetch_latest_version", return_value="0.3.1"),
+        patch("click.confirm", return_value=False),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        check_tool_is_current()
+
+    assert exc_info.value.code == 0
+
+
+def test_check_tool_is_current_continues_when_user_accepts():
+    """Does not exit when the user answers Yes."""
+    with (
+        patch("gds_idea_gh_kit.version.__version__", "0.3.0"),
+        patch("gds_idea_gh_kit.version._fetch_latest_version", return_value="0.3.1"),
+        patch("click.confirm", return_value=True),
+    ):
+        check_tool_is_current()  # should not raise


### PR DESCRIPTION
## Summary

- **Per-branch merge method enforcement**: Add `allowed_merge_methods` to branch protection config, so rulesets can restrict which merge strategies are available per target branch. This prevents the dev/prod history divergence problem caused by squash-merging between long-lived branches.
- **Version currency check**: Warn users if their installed `idea-gh` is outdated before running `audit` or `init`, with upgrade instructions and a prompt to continue.

## Motivation

CDK apps use a `feature -> dev -> prod` branching model. Previously, all merge methods were allowed on all branches, and repo settings only permitted squash merge. This caused `dev` and `prod` to diverge because squash merges between long-lived branches never advance the git merge base, leading to persistent merge conflicts.

The fix enforces:
- `dev` branch: only squash merge (clean history from feature PRs)
- `prod` branch: only merge commit (keeps dev/prod histories linked)

## Config changes

- `repo_settings.allow_merge_commit`: `false` -> `true` (enables the merge button globally)
- `cdk-app.dev.allowed_merge_methods`: `[squash]`
- `cdk-app.prod.allowed_merge_methods`: `[merge]`
- `cdk-app.prod.dismiss_stale_reviews`: explicitly set to `true`
- `python-package.main.allowed_merge_methods`: `[squash]`

## Changes

### `allowed_merge_methods`
- `models.py`: New `allowed_merge_methods` field on `BranchProtectionConfig` with validator
- `checks/branches.py`: Include in ruleset payload when non-empty; audit against expected config
- `config.yml` + `config.example.yml`: Updated with new settings
- 5 new tests covering audit pass/fail/skip and payload construction

### Version currency check
- New `version.py` module: fetches latest version from GDS IDEA PyPI index, warns if outdated
- `cli.py`: Wired into `audit` and `init` commands
- 11 new tests covering fetch, comparison, and user prompt behaviour

### Version bump
- `0.3.0` -> `0.3.1`