### PR TITLE
fix: accept both LICENSE and LICENCE spellings

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -21,7 +21,7 @@ repo_settings:
 
 required_files:
   - .gitignore
-  - LICENSE
+  - [LICENSE, LICENCE]
   - [README.md, docs/README.md]
   - .github/dependabot.yml
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gds-idea-gh-kit"
-version = "0.3.1"
+version = "0.3.2"
 description = "CLI tool for auditing and enforcing GitHub repo standards for GDS IDEA teams"
 readme = "README.md"
 authors = [

--- a/src/gds_idea_gh_kit/config.yml
+++ b/src/gds_idea_gh_kit/config.yml
@@ -21,7 +21,7 @@ repo_settings:
 
 required_files:
   - .gitignore
-  - LICENSE
+  - [LICENSE, LICENCE]
   - [README.md, docs/README.md]
   - .github/dependabot.yml
 


### PR DESCRIPTION
## Summary

- Change `required_files` config to accept either `LICENSE` or `LICENCE` (British spelling) using the existing alternatives syntax: `[LICENSE, LICENCE]`

## Why

UK government repos commonly use `LICENCE` (British spelling). The audit was failing these repos with "Required file missing: LICENSE" even though the file existed under the alternative spelling.