### PR TITLE
Add econ repo type with excluded_files and extra_teams

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -75,3 +75,25 @@ repo_types:
         bypass_teams: [gds-idea-super-admin]
         bypass_mode: pull_request
         allowed_merge_methods: [squash]
+
+  econ:
+    naming_pattern: "gds-idea-econ-{name}"
+    detection_files: []
+    default_branch: main
+    required_workflows: []
+    excluded_files:                        # global required_files entries to skip
+      - .github/dependabot.yml
+    extra_teams:                           # additional teams (on top of global teams)
+      gds-idea-econ: write
+    branch_protection:
+      main:
+        require_pr: true
+        required_approvals: 0
+        dismiss_stale_reviews: true
+        require_linear_history: false
+        required_review_teams: []
+        prevent_deletion: true
+        prevent_force_push: true
+        bypass_teams: [gds-idea-super-admin]
+        bypass_mode: pull_request
+        allowed_merge_methods: [merge, squash]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gds-idea-gh-kit"
-version = "0.3.1"
+version = "0.4.0"
 description = "CLI tool for auditing and enforcing GitHub repo standards for GDS IDEA teams"
 readme = "README.md"
 authors = [

--- a/src/gds_idea_gh_kit/audit.py
+++ b/src/gds_idea_gh_kit/audit.py
@@ -82,14 +82,24 @@ def audit_repo(
     # 2. Settings
     report.results.extend(settings.audit(owner, repo, config.repo_settings, client))
 
-    # 3. Teams
-    report.results.extend(teams.audit(owner, repo, config.teams, client))
+    # 3. Teams (global + type-specific extra teams)
+    all_teams = {**config.teams, **type_config.extra_teams}
+    report.results.extend(teams.audit(owner, repo, all_teams, client))
 
     # 4. Branches (default branch + rulesets)
     report.results.extend(branches.audit(owner, repo, type_config, client))
 
     # 5. Files + workflows
-    report.results.extend(files.audit(owner, repo, config.required_files, type_config.required_workflows, client))
+    report.results.extend(
+        files.audit(
+            owner,
+            repo,
+            config.required_files,
+            type_config.required_workflows,
+            client,
+            excluded_files=type_config.excluded_files,
+        )
+    )
 
     # 6. Security
     report.results.extend(security.audit(owner, repo, config.security, client))
@@ -133,9 +143,10 @@ def fix_repo(
     except Exception as e:
         fix_report.errors.append(f"settings fix failed: {e}")
 
-    # Teams
+    # Teams (global + type-specific extra teams)
     try:
-        changes = teams.fix(owner, repo, config.teams, client)
+        all_teams = {**config.teams, **type_config.extra_teams}
+        changes = teams.fix(owner, repo, all_teams, client)
         fix_report.changes.extend(f"teams: {c}" for c in changes)
     except Exception as e:
         fix_report.errors.append(f"teams fix failed: {e}")

--- a/src/gds_idea_gh_kit/checks/files.py
+++ b/src/gds_idea_gh_kit/checks/files.py
@@ -6,21 +6,39 @@ from gds_idea_gh_kit.github_client import GitHubClient
 from gds_idea_gh_kit.models import CheckResult, CheckStatus
 
 
+def _is_excluded(entry: str | list[str], excluded_files: list[str]) -> bool:
+    """Check whether a required_files entry should be skipped.
+
+    For a plain string, it's excluded if it appears in *excluded_files*.
+    For an OR-style list, it's excluded if **any** alternative appears in
+    *excluded_files* (the whole group is dropped).
+    """
+    if isinstance(entry, list):
+        return any(f in excluded_files for f in entry)
+    return entry in excluded_files
+
+
 def audit(
     owner: str,
     repo: str,
     required_files: list[str | list[str]],
     required_workflows: list[str],
     client: GitHubClient,
+    excluded_files: list[str] | None = None,
 ) -> list[CheckResult]:
     """Check that each required file and workflow exists in the repo.
 
     Entries in ``required_files`` can be a plain string (file must exist)
     or a list of strings (at least one must exist — OR logic).
+
+    Any entry matching *excluded_files* is silently skipped.
     """
+    excluded = excluded_files or []
     results = []
 
     for entry in required_files:
+        if _is_excluded(entry, excluded):
+            continue
         if isinstance(entry, list):
             # OR logic: pass if any alternative exists
             found = None

--- a/src/gds_idea_gh_kit/config.yml
+++ b/src/gds_idea_gh_kit/config.yml
@@ -76,3 +76,25 @@ repo_types:
         bypass_teams: [gds-idea-super-admin]
         bypass_mode: pull_request
         allowed_merge_methods: [squash]
+
+  econ:
+    naming_pattern: "gds-idea-econ-{name}"
+    detection_files: []
+    default_branch: main
+    required_workflows: []
+    excluded_files:
+      - .github/dependabot.yml
+    extra_teams:
+      gds-idea-econ: write
+    branch_protection:
+      main:
+        require_pr: true
+        required_approvals: 0
+        dismiss_stale_reviews: true
+        require_linear_history: false
+        required_review_teams: []
+        prevent_deletion: true
+        prevent_force_push: true
+        bypass_teams: [gds-idea-super-admin]
+        bypass_mode: pull_request
+        allowed_merge_methods: [merge, squash]

--- a/src/gds_idea_gh_kit/init.py
+++ b/src/gds_idea_gh_kit/init.py
@@ -140,8 +140,9 @@ def init_repo(
             client.create_branch(org, repo_name, branch_name, default_branch)
             steps.append(f"Created {branch_name} branch from {default_branch}")
 
-    # 6. Attach teams
-    for team_slug, perm in config.teams.items():
+    # 6. Attach teams (global + type-specific)
+    all_teams = {**config.teams, **type_config.extra_teams}
+    for team_slug, perm in all_teams.items():
         api_perm = _PERM_TO_API.get(perm, perm)
         client.set_team_repo_permission(org, team_slug, org, repo_name, api_perm)
         steps.append(f"Attached team {team_slug} ({perm})")

--- a/src/gds_idea_gh_kit/models.py
+++ b/src/gds_idea_gh_kit/models.py
@@ -130,6 +130,21 @@ class RepoTypeConfig(BaseModel):
     branch_protection: dict[str, BranchProtectionConfig] = Field(default_factory=dict)
     required_workflows: list[str] = Field(default_factory=list)
     """Workflow filenames expected in .github/workflows/ (e.g. ['lint.yml', 'test.yml'])."""
+    excluded_files: list[str] = Field(default_factory=list)
+    """Global required_files entries to skip for this repo type."""
+    extra_teams: dict[str, str] = Field(default_factory=dict)
+    """Additional teams to attach for this repo type (additive to global teams)."""
+
+    @field_validator("extra_teams")
+    @classmethod
+    def extra_team_permissions_must_be_valid(cls, v: dict[str, str]) -> dict[str, str]:
+        valid = {"admin", "write", "read", "maintain", "triage"}
+        for team, perm in v.items():
+            if perm not in valid:
+                raise ValueError(
+                    f"Team '{team}' has invalid permission '{perm}'. Must be one of: {', '.join(sorted(valid))}"
+                )
+        return v
 
     @field_validator("naming_pattern")
     @classmethod

--- a/tests/test_checks/test_files.py
+++ b/tests/test_checks/test_files.py
@@ -164,3 +164,61 @@ def test_alternative_none_exist(httpx_mock: HTTPXMock, gh_client: GitHubClient):
     assert "README.md" in results[0].message
     assert "docs/README.md" in results[0].message
     assert results[0].fix_available is False
+
+
+# --- excluded_files ---
+
+
+def test_excluded_file_is_skipped(httpx_mock: HTTPXMock, gh_client: GitHubClient):
+    """A file in excluded_files should not be checked at all."""
+    httpx_mock.add_response(
+        url="https://api.github.com/repos/co-cddo/my-repo/contents/.gitignore",
+        json={"name": ".gitignore"},
+    )
+    # No mock for dependabot.yml — it should never be requested
+
+    results = files.audit(
+        "co-cddo",
+        "my-repo",
+        [".gitignore", ".github/dependabot.yml"],
+        [],
+        gh_client,
+        excluded_files=[".github/dependabot.yml"],
+    )
+    assert len(results) == 1
+    assert results[0].status == CheckStatus.PASSED
+    assert ".gitignore" in results[0].message
+
+
+def test_excluded_or_entry_is_skipped(httpx_mock: HTTPXMock, gh_client: GitHubClient):
+    """An OR-style entry is excluded if any alternative appears in excluded_files."""
+    httpx_mock.add_response(
+        url="https://api.github.com/repos/co-cddo/my-repo/contents/.gitignore",
+        json={"name": ".gitignore"},
+    )
+
+    results = files.audit(
+        "co-cddo",
+        "my-repo",
+        [".gitignore", ["README.md", "docs/README.md"]],
+        [],
+        gh_client,
+        excluded_files=["README.md"],
+    )
+    assert len(results) == 1
+    assert ".gitignore" in results[0].message
+
+
+def test_excluded_files_empty_by_default(httpx_mock: HTTPXMock, gh_client: GitHubClient):
+    """When excluded_files is not passed, all files are checked (backwards compat)."""
+    httpx_mock.add_response(
+        url="https://api.github.com/repos/co-cddo/my-repo/contents/.gitignore",
+        json={"name": ".gitignore"},
+    )
+    httpx_mock.add_response(
+        url="https://api.github.com/repos/co-cddo/my-repo/contents/LICENSE",
+        json={"name": "LICENSE"},
+    )
+
+    results = files.audit("co-cddo", "my-repo", [".gitignore", "LICENSE"], [], gh_client)
+    assert len(results) == 2

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -15,9 +15,11 @@ def test_load_bundled_config():
     assert config.org == "co-cddo"
     assert len(config.repo_types) > 0
     assert len(config.repo_prefixes) > 0
-    # Each repo type should have detection files
+    # Each repo type should have detection files (except name-only types like econ)
+    name_only_types = {"econ"}
     for type_name, type_config in config.repo_types.items():
-        assert len(type_config.detection_files) > 0, f"{type_name} has no detection_files"
+        if type_name not in name_only_types:
+            assert len(type_config.detection_files) > 0, f"{type_name} has no detection_files"
 
 
 def test_load_custom_config(tmp_path):
@@ -107,6 +109,15 @@ def test_naming_pattern_requires_placeholder():
         RepoTypeConfig(naming_pattern="no-placeholder", default_branch="main")
 
 
+def test_invalid_extra_team_permission():
+    with pytest.raises(ValidationError, match="invalid permission"):
+        RepoTypeConfig(
+            naming_pattern="gds-idea-econ-{name}",
+            default_branch="main",
+            extra_teams={"gds-idea-econ": "superadmin"},
+        )
+
+
 def test_extra_fields_rejected():
     with pytest.raises(ValidationError, match="extra"):
         Config(org="co-cddo", bogus_field="oops")
@@ -127,6 +138,16 @@ def test_extract_name():
     rt = RepoTypeConfig(naming_pattern="gds-idea-app-{name}", default_branch="dev")
     assert rt.extract_name("gds-idea-app-my-dashboard") == "my-dashboard"
     assert rt.extract_name("other-repo") is None
+
+
+def test_econ_naming_pattern():
+    rt = RepoTypeConfig(naming_pattern="gds-idea-econ-{name}", default_branch="main")
+    assert rt.matches_name("gds-idea-econ-housing") is True
+    assert rt.matches_name("gds-idea-econ-trade-model") is True
+    assert rt.matches_name("gds-idea-econ-") is False
+    assert rt.matches_name("gds-idea-app-foo") is False
+    assert rt.matches_name("gds-idea-housing") is False
+    assert rt.extract_name("gds-idea-econ-housing") == "housing"
 
 
 def test_has_known_prefix():

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -284,3 +284,101 @@ def test_get_repo_name_from_directory(tmp_path):
         mock_path.cwd.return_value = tmp_path / "gds-idea-app-my-thing"
         name = get_repo_name_from_directory()
         assert name == "gds-idea-app-my-thing"
+
+
+# --- extra_teams ---
+
+
+def _econ_config() -> Config:
+    return Config(
+        org="co-cddo",
+        repo_prefixes=["gds-idea-"],
+        teams={
+            "gds-idea-all": "read",
+            "gds-idea-ds": "maintain",
+        },
+        repo_settings=RepoSettings(),
+        required_files=[".gitignore"],
+        security=SecurityConfig(),
+        repo_types={
+            "econ": RepoTypeConfig(
+                naming_pattern="gds-idea-econ-{name}",
+                detection_files=[],
+                default_branch="main",
+                required_workflows=[],
+                excluded_files=[".github/dependabot.yml"],
+                extra_teams={"gds-idea-econ": "write"},
+                branch_protection={
+                    "main": BranchProtectionConfig(
+                        require_pr=True,
+                        required_approvals=0,
+                        prevent_deletion=True,
+                        prevent_force_push=True,
+                        bypass_teams=["gds-idea-super-admin"],
+                        bypass_mode="pull_request",
+                    ),
+                },
+            ),
+        },
+    )
+
+
+@patch("gds_idea_gh_kit.init._run_git")
+def test_init_econ_attaches_extra_teams(mock_git, httpx_mock: HTTPXMock, gh_client: GitHubClient):
+    """Init for econ type should attach both global teams and extra_teams."""
+    mock_git.side_effect = _mock_git_success()
+
+    # 1. Create repo
+    httpx_mock.add_response(
+        url=f"{BASE}/orgs/co-cddo/repos",
+        method="POST",
+        json={"name": "gds-idea-econ-housing"},
+        status_code=201,
+    )
+
+    # 2. Update repo settings
+    httpx_mock.add_response(
+        url=f"{BASE}/repos/co-cddo/gds-idea-econ-housing",
+        method="PATCH",
+        json={"name": "gds-idea-econ-housing"},
+    )
+
+    # 3. Attach teams (2 global + 1 extra)
+    for team in ["gds-idea-all", "gds-idea-ds", "gds-idea-econ"]:
+        httpx_mock.add_response(
+            url=f"{BASE}/orgs/co-cddo/teams/{team}/repos/co-cddo/gds-idea-econ-housing",
+            method="PUT",
+            status_code=204,
+        )
+
+    # 4. Create ruleset — need team ID lookup for bypass
+    httpx_mock.add_response(
+        url=f"{BASE}/orgs/co-cddo/teams/gds-idea-super-admin",
+        method="GET",
+        json={"id": 999, "slug": "gds-idea-super-admin"},
+    )
+    httpx_mock.add_response(
+        url=f"{BASE}/repos/co-cddo/gds-idea-econ-housing/rulesets",
+        method="POST",
+        json={"id": 1, "name": "idea-gh: main"},
+        status_code=201,
+    )
+
+    # 5. Security
+    httpx_mock.add_response(
+        url=f"{BASE}/repos/co-cddo/gds-idea-econ-housing/vulnerability-alerts",
+        method="PUT",
+        status_code=204,
+    )
+    httpx_mock.add_response(
+        url=f"{BASE}/repos/co-cddo/gds-idea-econ-housing/automated-security-fixes",
+        method="PUT",
+        status_code=204,
+    )
+
+    config = _econ_config()
+    steps = init_repo("gds-idea-econ-housing", config, "econ", gh_client)
+
+    assert any("gds-idea-econ" in s and "write" in s for s in steps)
+    assert any("gds-idea-all" in s for s in steps)
+    assert any("gds-idea-ds" in s for s in steps)


### PR DESCRIPTION
## Summary

- Adds a new `econ` repo type for the economics team, designed for easier git adoption
- Introduces two new per-type config fields: `excluded_files` (skip global required files) and `extra_teams` (additional teams on top of global)

## Econ type config

- **Naming**: `gds-idea-econ-{name}`
- **Branch protection on main**: PRs required but 0 approvals needed (no review gate)
- **Merge methods**: merge and squash allowed
- **No required workflows** — no CI/CD imposed
- **Dependabot excluded** via `excluded_files`
- **`gds-idea-econ: write`** added via `extra_teams` (on top of global teams)

## New model fields

- `RepoTypeConfig.excluded_files` — list of global `required_files` entries to skip for this type
- `RepoTypeConfig.extra_teams` — additional teams to attach, additive to global teams (with permission validation)

Both fields default to empty, so existing types are unaffected.

## Changes

- `models.py` — new fields + validation
- `config.yml` / `config.example.yml` — econ type definition
- `checks/files.py` — filter excluded files before audit
- `audit.py` — pass excluded_files and merge extra_teams in audit + fix paths
- `init.py` — merge extra_teams when attaching teams during repo creation
- Tests — 7 new tests covering naming, exclusion, extra teams, and econ init flow