### PR TITLE
Add global labels: audit, fix, and init support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gds-idea-gh-kit"
-version = "0.5.0"
+version = "0.5.1"
 description = "CLI tool for auditing and enforcing GitHub repo standards for GDS IDEA teams"
 readme = "README.md"
 authors = [

--- a/src/gds_idea_gh_kit/audit.py
+++ b/src/gds_idea_gh_kit/audit.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from gds_idea_gh_kit.checks import branches, files, naming, security, settings, teams
+from gds_idea_gh_kit.checks import branches, files, labels, naming, security, settings, teams
 from gds_idea_gh_kit.github_client import GitHubClient
 from gds_idea_gh_kit.models import (
     AuditReport,
@@ -104,6 +104,9 @@ def audit_repo(
     # 6. Security
     report.results.extend(security.audit(owner, repo, config.security, client))
 
+    # 7. Labels
+    report.results.extend(labels.audit(owner, repo, config.labels, client))
+
     return report
 
 
@@ -165,6 +168,13 @@ def fix_repo(
         fix_report.changes.extend(f"security: {c}" for c in changes)
     except Exception as e:
         fix_report.errors.append(f"security fix failed: {e}")
+
+    # Labels
+    try:
+        changes = labels.fix(owner, repo, config.labels, client)
+        fix_report.changes.extend(f"labels: {c}" for c in changes)
+    except Exception as e:
+        fix_report.errors.append(f"labels fix failed: {e}")
 
     return fix_report
 

--- a/src/gds_idea_gh_kit/checks/labels.py
+++ b/src/gds_idea_gh_kit/checks/labels.py
@@ -1,0 +1,77 @@
+"""Check that required labels exist on the repository."""
+
+from __future__ import annotations
+
+from gds_idea_gh_kit.github_client import GitHubClient
+from gds_idea_gh_kit.models import CheckResult, CheckStatus, LabelConfig
+
+
+def audit(owner: str, repo: str, labels: list[LabelConfig], client: GitHubClient) -> list[CheckResult]:
+    """Check that each required label exists on the repo (name only).
+
+    Args:
+        owner: Repository owner (org name).
+        repo: Repository name.
+        labels: Required labels from config.
+        client: GitHub API client.
+
+    Returns:
+        One CheckResult per required label.
+    """
+    if not labels:
+        return []
+
+    existing = {label["name"] for label in client.list_labels(owner, repo)}
+    results = []
+
+    for label in labels:
+        if label.name in existing:
+            results.append(
+                CheckResult(
+                    name=f"labels.{label.name}",
+                    status=CheckStatus.PASSED,
+                    message=f"Label '{label.name}' exists",
+                )
+            )
+        else:
+            results.append(
+                CheckResult(
+                    name=f"labels.{label.name}",
+                    status=CheckStatus.FAILED,
+                    message=f"Label '{label.name}' is missing",
+                    fix_available=True,
+                )
+            )
+
+    return results
+
+
+def fix(owner: str, repo: str, labels: list[LabelConfig], client: GitHubClient) -> list[str]:
+    """Create missing labels and update existing ones to match config.
+
+    Args:
+        owner: Repository owner (org name).
+        repo: Repository name.
+        labels: Required labels from config.
+        client: GitHub API client.
+
+    Returns:
+        List of changes made.
+    """
+    if not labels:
+        return []
+
+    existing = {label["name"]: label for label in client.list_labels(owner, repo)}
+    changes = []
+
+    for label in labels:
+        if label.name not in existing:
+            client.create_label(owner, repo, label.name, label.color, label.description)
+            changes.append(f"Created label '{label.name}'")
+        else:
+            current = existing[label.name]
+            if current.get("color") != label.color or current.get("description", "") != label.description:
+                client.update_label(owner, repo, label.name, label.color, label.description)
+                changes.append(f"Updated label '{label.name}'")
+
+    return changes

--- a/src/gds_idea_gh_kit/config.yml
+++ b/src/gds_idea_gh_kit/config.yml
@@ -29,6 +29,17 @@ security:
   vulnerability_alerts: true
   automated_security_fixes: true
 
+labels:
+  - name: bump:major
+    color: d73a4a
+    description: "Release: major version bump"
+  - name: bump:minor
+    color: 0e8a16
+    description: "Release: minor version bump"
+  - name: bump:patch
+    color: e4e669
+    description: "Release: patch version bump (default)"
+
 repo_types:
   cdk-app:
     naming_pattern: "gds-idea-app-{name}"

--- a/src/gds_idea_gh_kit/github_client.py
+++ b/src/gds_idea_gh_kit/github_client.py
@@ -337,3 +337,25 @@ class GitHubClient:
     def delete_branch(self, owner: str, repo: str, branch: str) -> None:
         """Delete a branch via the Git Refs API."""
         self._request("DELETE", f"/repos/{owner}/{repo}/git/refs/heads/{branch}")
+
+    # --- Labels ---
+
+    def list_labels(self, owner: str, repo: str) -> list[dict]:
+        """List all labels for a repository."""
+        return self._request("GET", f"/repos/{owner}/{repo}/labels").json()
+
+    def create_label(self, owner: str, repo: str, name: str, color: str, description: str = "") -> dict:
+        """Create a label on a repository."""
+        return self._request(
+            "POST",
+            f"/repos/{owner}/{repo}/labels",
+            json={"name": name, "color": color, "description": description},
+        ).json()
+
+    def update_label(self, owner: str, repo: str, name: str, color: str, description: str = "") -> dict:
+        """Update an existing label's colour and description."""
+        return self._request(
+            "PATCH",
+            f"/repos/{owner}/{repo}/labels/{name}",
+            json={"color": color, "description": description},
+        ).json()

--- a/src/gds_idea_gh_kit/init.py
+++ b/src/gds_idea_gh_kit/init.py
@@ -163,4 +163,9 @@ def init_repo(
         client.enable_automated_security_fixes(org, repo_name)
         steps.append("Enabled automated security fixes")
 
+    # 9. Create labels
+    for label in config.labels:
+        client.create_label(org, repo_name, label.name, label.color, label.description)
+        steps.append(f"Created label '{label.name}'")
+
     return steps

--- a/src/gds_idea_gh_kit/models.py
+++ b/src/gds_idea_gh_kit/models.py
@@ -163,6 +163,13 @@ class RepoTypeConfig(BaseModel):
         return match.group(1) if match else None
 
 
+class LabelConfig(BaseModel):
+    name: str
+    color: str
+    """Hex colour without leading #."""
+    description: str = ""
+
+
 class RepoSettings(BaseModel):
     delete_branch_on_merge: bool = True
     allow_squash_merge: bool = True
@@ -191,6 +198,8 @@ class Config(BaseModel):
     """Required files. A string means the file must exist. A list of strings
     means at least one of the alternatives must exist (OR logic)."""
     security: SecurityConfig = Field(default_factory=SecurityConfig)
+    labels: list[LabelConfig] = Field(default_factory=list)
+    """Labels to create on every repo (checked by audit, created by init)."""
     repo_types: dict[str, RepoTypeConfig] = Field(default_factory=dict)
 
     @field_validator("default_visibility")

--- a/tests/test_checks/test_labels.py
+++ b/tests/test_checks/test_labels.py
@@ -1,0 +1,132 @@
+"""Tests for the labels check."""
+
+from pytest_httpx import HTTPXMock
+
+from gds_idea_gh_kit.checks import labels
+from gds_idea_gh_kit.github_client import GitHubClient
+from gds_idea_gh_kit.models import CheckStatus, LabelConfig
+
+BASE = "https://api.github.com"
+
+_CONFIGURED = [
+    LabelConfig(name="bump:major", color="d73a4a", description="Release: major version bump"),
+    LabelConfig(name="bump:minor", color="0e8a16", description="Release: minor version bump"),
+    LabelConfig(name="bump:patch", color="e4e669", description="Release: patch version bump (default)"),
+]
+
+
+def test_all_labels_present(httpx_mock: HTTPXMock, gh_client: GitHubClient):
+    """All configured labels exist -> all pass."""
+    httpx_mock.add_response(
+        url=f"{BASE}/repos/co-cddo/my-repo/labels",
+        json=[
+            {"name": "bump:major", "color": "d73a4a", "description": "Release: major version bump"},
+            {"name": "bump:minor", "color": "0e8a16", "description": "Release: minor version bump"},
+            {"name": "bump:patch", "color": "e4e669", "description": "Release: patch version bump (default)"},
+        ],
+    )
+
+    results = labels.audit("co-cddo", "my-repo", _CONFIGURED, gh_client)
+    assert len(results) == 3
+    assert all(r.status == CheckStatus.PASSED for r in results)
+
+
+def test_missing_label_fails(httpx_mock: HTTPXMock, gh_client: GitHubClient):
+    """A missing label produces a FAILED result with fix_available=True."""
+    httpx_mock.add_response(
+        url=f"{BASE}/repos/co-cddo/my-repo/labels",
+        json=[
+            {"name": "bump:minor", "color": "0e8a16", "description": ""},
+            {"name": "bump:patch", "color": "e4e669", "description": ""},
+        ],
+    )
+
+    results = labels.audit("co-cddo", "my-repo", _CONFIGURED, gh_client)
+    failed = [r for r in results if r.status == CheckStatus.FAILED]
+    assert len(failed) == 1
+    assert "bump:major" in failed[0].name
+    assert failed[0].fix_available is True
+
+
+def test_all_labels_missing(httpx_mock: HTTPXMock, gh_client: GitHubClient):
+    """All labels missing -> all fail with fix_available."""
+    httpx_mock.add_response(
+        url=f"{BASE}/repos/co-cddo/my-repo/labels",
+        json=[],
+    )
+
+    results = labels.audit("co-cddo", "my-repo", _CONFIGURED, gh_client)
+    assert len(results) == 3
+    assert all(r.status == CheckStatus.FAILED for r in results)
+    assert all(r.fix_available for r in results)
+
+
+def test_no_configured_labels_returns_empty(httpx_mock: HTTPXMock, gh_client: GitHubClient):
+    """Empty label config -> no API call, no results."""
+    results = labels.audit("co-cddo", "my-repo", [], gh_client)
+    assert results == []
+
+
+def test_fix_creates_missing_labels(httpx_mock: HTTPXMock, gh_client: GitHubClient):
+    """fix() creates labels that are missing."""
+    httpx_mock.add_response(
+        url=f"{BASE}/repos/co-cddo/my-repo/labels",
+        json=[
+            {"name": "bump:minor", "color": "0e8a16", "description": "Release: minor version bump"},
+            {"name": "bump:patch", "color": "e4e669", "description": "Release: patch version bump (default)"},
+        ],
+    )
+    httpx_mock.add_response(
+        url=f"{BASE}/repos/co-cddo/my-repo/labels",
+        method="POST",
+        json={"name": "bump:major", "color": "d73a4a", "description": "Release: major version bump"},
+        status_code=201,
+    )
+
+    changes = labels.fix("co-cddo", "my-repo", _CONFIGURED, gh_client)
+    assert len(changes) == 1
+    assert "bump:major" in changes[0]
+    assert "Created" in changes[0]
+
+
+def test_fix_updates_label_with_wrong_colour(httpx_mock: HTTPXMock, gh_client: GitHubClient):
+    """fix() updates labels whose colour doesn't match config."""
+    httpx_mock.add_response(
+        url=f"{BASE}/repos/co-cddo/my-repo/labels",
+        json=[
+            {"name": "bump:major", "color": "ffffff", "description": "Release: major version bump"},
+            {"name": "bump:minor", "color": "0e8a16", "description": "Release: minor version bump"},
+            {"name": "bump:patch", "color": "e4e669", "description": "Release: patch version bump (default)"},
+        ],
+    )
+    httpx_mock.add_response(
+        url=f"{BASE}/repos/co-cddo/my-repo/labels/bump:major",
+        method="PATCH",
+        json={"name": "bump:major", "color": "d73a4a", "description": "Release: major version bump"},
+    )
+
+    changes = labels.fix("co-cddo", "my-repo", _CONFIGURED, gh_client)
+    assert len(changes) == 1
+    assert "bump:major" in changes[0]
+    assert "Updated" in changes[0]
+
+
+def test_fix_no_changes_when_all_match(httpx_mock: HTTPXMock, gh_client: GitHubClient):
+    """fix() returns empty list when all labels already match."""
+    httpx_mock.add_response(
+        url=f"{BASE}/repos/co-cddo/my-repo/labels",
+        json=[
+            {"name": "bump:major", "color": "d73a4a", "description": "Release: major version bump"},
+            {"name": "bump:minor", "color": "0e8a16", "description": "Release: minor version bump"},
+            {"name": "bump:patch", "color": "e4e669", "description": "Release: patch version bump (default)"},
+        ],
+    )
+
+    changes = labels.fix("co-cddo", "my-repo", _CONFIGURED, gh_client)
+    assert changes == []
+
+
+def test_fix_empty_config_returns_empty(httpx_mock: HTTPXMock, gh_client: GitHubClient):
+    """fix() with no configured labels -> no API calls, no changes."""
+    changes = labels.fix("co-cddo", "my-repo", [], gh_client)
+    assert changes == []

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -16,6 +16,7 @@ from gds_idea_gh_kit.init import (
 from gds_idea_gh_kit.models import (
     BranchProtectionConfig,
     Config,
+    LabelConfig,
     RepoSettings,
     RepoTypeConfig,
     SecurityConfig,
@@ -37,6 +38,11 @@ def _test_config() -> Config:
         repo_settings=RepoSettings(),
         required_files=[".gitignore"],
         security=SecurityConfig(),
+        labels=[
+            LabelConfig(name="bump:major", color="d73a4a", description="Release: major version bump"),
+            LabelConfig(name="bump:minor", color="0e8a16", description="Release: minor version bump"),
+            LabelConfig(name="bump:patch", color="e4e669", description="Release: patch version bump (default)"),
+        ],
         repo_types={
             "cdk-app": RepoTypeConfig(
                 naming_pattern="gds-idea-app-{name}",
@@ -172,6 +178,15 @@ def _mock_all_api_calls(httpx_mock: HTTPXMock):
         status_code=204,
     )
 
+    # 8. Labels
+    for label in ["bump:major", "bump:minor", "bump:patch"]:
+        httpx_mock.add_response(
+            url=f"{BASE}/repos/co-cddo/gds-idea-app-dashboard/labels",
+            method="POST",
+            json={"name": label},
+            status_code=201,
+        )
+
 
 @patch("gds_idea_gh_kit.init._run_git")
 def test_init_repo_full_flow(mock_git, httpx_mock: HTTPXMock, gh_client: GitHubClient):
@@ -196,6 +211,9 @@ def test_init_repo_full_flow(mock_git, httpx_mock: HTTPXMock, gh_client: GitHubC
     assert any("ruleset" in s and "prod" in s for s in steps)
     assert any("vulnerability" in s for s in steps)
     assert any("automated security" in s for s in steps)
+    assert any("bump:major" in s for s in steps)
+    assert any("bump:minor" in s for s in steps)
+    assert any("bump:patch" in s for s in steps)
 
 
 @patch("gds_idea_gh_kit.init._run_git")

--- a/uv.lock
+++ b/uv.lock
@@ -56,7 +56,7 @@ wheels = [
 
 [[package]]
 name = "gds-idea-gh-kit"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Adds `bump:major`, `bump:minor`, `bump:patch` labels as a global config concept applied to all repo types.

## Changes

- **`models.py`**: new `LabelConfig` model; `Config` gets a top-level `labels` list
- **`github_client.py`**: `list_labels`, `create_label`, `update_label` methods
- **`checks/labels.py`**: `audit()` checks label names exist; `fix()` creates missing and stamps existing to match config (name, colour, description)
- **`audit.py`**: labels wired into `audit_repo()` and `fix_repo()`
- **`init.py`**: creates all configured labels as step 9 (after security)
- **`config.yml`**: three bump labels defined at top level

## Tested locally

```
idea-gh audit          # showed 3 missing labels as auto-fixable
idea-gh audit --fix    # created bump:major, bump:minor, bump:patch on this repo
```

Closes #32