### PR TITLE
Fix crash deleting stale branch after default branch rename

### DIFF
--- a/src/gds_idea_gh_kit/cli.py
+++ b/src/gds_idea_gh_kit/cli.py
@@ -146,15 +146,28 @@ def _render_fix_result(fix_result):
 
 def _handle_stale_branches(fix_result, owner, repo, client):
     """Prompt the user about stale branches left behind after a default branch change."""
+    from gds_idea_gh_kit.github_client import GitHubClientError
+
     for stale in fix_result.stale_branches:
         click.echo()
+
+        # GitHub's branch rename is asynchronous — a branch reported as
+        # "stale" right after a rename may have since been removed once
+        # the rename actually completed. Re-check before prompting.
+        if not client.branch_exists(owner, repo, stale.branch):
+            click.echo(f"Branch '{stale.branch}' no longer exists (GitHub's rename cleanup already removed it).")
+            continue
+
         if stale.is_merged:
             click.echo(
                 f"Branch '{stale.branch}' is fully merged into '{stale.default_branch}' and is no longer needed."
             )
             if click.confirm(f"Delete '{stale.branch}'?", default=False):
-                client.delete_branch(owner, repo, stale.branch)
-                click.echo(f"  \u2713 Deleted branch '{stale.branch}'")
+                try:
+                    client.delete_branch(owner, repo, stale.branch)
+                    click.echo(f"  \u2713 Deleted branch '{stale.branch}'")
+                except GitHubClientError:
+                    click.echo(f"  Branch '{stale.branch}' was already removed.")
             else:
                 click.echo(f"  Leaving '{stale.branch}' in place.")
         else:
@@ -167,15 +180,20 @@ def _handle_stale_branches(fix_result, owner, repo, client):
                 f"{stale.default_branch}...{stale.branch} --jq '.commits[].commit.message'"
             )
             if click.confirm(f"Delete '{stale.branch}' anyway?", default=False):
-                client.delete_branch(owner, repo, stale.branch)
-                click.echo(f"  \u2713 Deleted branch '{stale.branch}'")
+                try:
+                    client.delete_branch(owner, repo, stale.branch)
+                    click.echo(f"  \u2713 Deleted branch '{stale.branch}'")
+                except GitHubClientError:
+                    click.echo(f"  Branch '{stale.branch}' was already removed.")
             else:
                 click.echo(f"  Leaving '{stale.branch}' in place.")
 
 
-def _warn_stale_branches(fix_result, owner, repo):
+def _warn_stale_branches(fix_result, owner, repo, client):
     """Print warnings about stale branches (non-interactive, for --all mode)."""
     for stale in fix_result.stale_branches:
+        if not client.branch_exists(owner, repo, stale.branch):
+            continue
         if stale.is_merged:
             click.echo(f"  ! Branch '{stale.branch}' is fully merged into '{stale.default_branch}' and can be deleted:")
             click.echo(f"    gh api -X DELETE repos/{owner}/{repo}/git/refs/heads/{stale.branch}")
@@ -245,7 +263,7 @@ def _audit_all_repos(
             try:
                 fix_result = fix_repo(config.org, repo_name, config, client, detected_type)
                 _render_fix_result(fix_result)
-                _warn_stale_branches(fix_result, config.org, repo_name)
+                _warn_stale_branches(fix_result, config.org, repo_name, client)
 
                 # Re-audit to show updated state
                 click.echo()

--- a/src/gds_idea_gh_kit/github_client.py
+++ b/src/gds_idea_gh_kit/github_client.py
@@ -340,6 +340,14 @@ class GitHubClient:
         """
         return self._request("GET", f"/repos/{owner}/{repo}/compare/{base}...{head}").json()
 
+    def branch_exists(self, owner: str, repo: str, branch: str) -> bool:
+        """Check if a branch still exists."""
+        try:
+            self._request("GET", f"/repos/{owner}/{repo}/git/ref/heads/{branch}")
+            return True
+        except GitHubClientError:
+            return False
+
     def delete_branch(self, owner: str, repo: str, branch: str) -> None:
         """Delete a branch via the Git Refs API."""
         self._request("DELETE", f"/repos/{owner}/{repo}/git/refs/heads/{branch}")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,113 @@
+"""Tests for cli.py helper functions (not full CLI invocations)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from gds_idea_gh_kit.cli import _handle_stale_branches, _warn_stale_branches
+from gds_idea_gh_kit.github_client import GitHubClientError
+from gds_idea_gh_kit.models import FixReport, StaleBranch
+
+
+def _fix_result_with_stale(branch: str = "main", default_branch: str = "dev", ahead_by: int = 0) -> FixReport:
+    return FixReport(
+        repo_name="my-repo",
+        repo_type="cdk-app",
+        stale_branches=[StaleBranch(branch=branch, default_branch=default_branch, ahead_by=ahead_by)],
+    )
+
+
+# --- _handle_stale_branches ---
+
+
+def test_handle_stale_branches_skips_already_deleted_branch(monkeypatch, capsys):
+    """GitHub's rename is async — if the branch is already gone, don't prompt or crash."""
+    client = MagicMock()
+    client.branch_exists.return_value = False
+
+    confirm_called = False
+
+    def fake_confirm(*args, **kwargs):
+        nonlocal confirm_called
+        confirm_called = True
+        return True
+
+    monkeypatch.setattr("click.confirm", fake_confirm)
+
+    fix_result = _fix_result_with_stale()
+    _handle_stale_branches(fix_result, "co-cddo", "my-repo", client)
+
+    assert confirm_called is False
+    client.delete_branch.assert_not_called()
+    assert "no longer exists" in capsys.readouterr().out
+
+
+def test_handle_stale_branches_deletes_merged_branch(monkeypatch):
+    client = MagicMock()
+    client.branch_exists.return_value = True
+    monkeypatch.setattr("click.confirm", lambda *a, **k: True)
+
+    fix_result = _fix_result_with_stale()
+    _handle_stale_branches(fix_result, "co-cddo", "my-repo", client)
+
+    client.delete_branch.assert_called_once_with("co-cddo", "my-repo", "main")
+
+
+def test_handle_stale_branches_declines_deletion(monkeypatch):
+    client = MagicMock()
+    client.branch_exists.return_value = True
+    monkeypatch.setattr("click.confirm", lambda *a, **k: False)
+
+    fix_result = _fix_result_with_stale()
+    _handle_stale_branches(fix_result, "co-cddo", "my-repo", client)
+
+    client.delete_branch.assert_not_called()
+
+
+def test_handle_stale_branches_survives_late_delete_failure(monkeypatch, capsys):
+    """branch_exists said True, but delete races with GitHub's async rename and 404s."""
+    client = MagicMock()
+    client.branch_exists.return_value = True
+    client.delete_branch.side_effect = GitHubClientError("Not found")
+    monkeypatch.setattr("click.confirm", lambda *a, **k: True)
+
+    fix_result = _fix_result_with_stale()
+    _handle_stale_branches(fix_result, "co-cddo", "my-repo", client)  # should not raise
+
+    assert "already removed" in capsys.readouterr().out
+
+
+def test_handle_stale_branches_unmerged_branch_prompt(monkeypatch):
+    client = MagicMock()
+    client.branch_exists.return_value = True
+    monkeypatch.setattr("click.confirm", lambda *a, **k: True)
+
+    fix_result = _fix_result_with_stale(ahead_by=3)
+    _handle_stale_branches(fix_result, "co-cddo", "my-repo", client)
+
+    client.delete_branch.assert_called_once_with("co-cddo", "my-repo", "main")
+
+
+# --- _warn_stale_branches ---
+
+
+def test_warn_stale_branches_skips_already_deleted_branch(capsys):
+    client = MagicMock()
+    client.branch_exists.return_value = False
+
+    fix_result = _fix_result_with_stale()
+    _warn_stale_branches(fix_result, "co-cddo", "my-repo", client)
+
+    assert capsys.readouterr().out == ""
+
+
+def test_warn_stale_branches_warns_for_existing_merged_branch(capsys):
+    client = MagicMock()
+    client.branch_exists.return_value = True
+
+    fix_result = _fix_result_with_stale()
+    _warn_stale_branches(fix_result, "co-cddo", "my-repo", client)
+
+    out = capsys.readouterr().out
+    assert "fully merged" in out
+    assert "main" in out

--- a/tests/test_github_client.py
+++ b/tests/test_github_client.py
@@ -152,6 +152,29 @@ def test_compare_branches(httpx_mock: HTTPXMock):
     assert result["ahead_by"] == 3
 
 
+# --- branch_exists ---
+
+
+def test_branch_exists_true(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(
+        url=f"{BASE}/repos/co-cddo/my-repo/git/ref/heads/main",
+        json={"ref": "refs/heads/main"},
+    )
+
+    client = GitHubClient(token="fake-token", org="co-cddo")
+    assert client.branch_exists("co-cddo", "my-repo", "main") is True
+
+
+def test_branch_exists_false(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(
+        url=f"{BASE}/repos/co-cddo/my-repo/git/ref/heads/main",
+        status_code=404,
+    )
+
+    client = GitHubClient(token="fake-token", org="co-cddo")
+    assert client.branch_exists("co-cddo", "my-repo", "main") is False
+
+
 # --- delete_branch ---
 
 


### PR DESCRIPTION
## Summary

Fixes #28.

GitHub's `POST /repos/{owner}/{repo}/branches/{branch}/rename` endpoint is asynchronous. `checks/branches.py::fix()` checks whether the old default branch ref still exists immediately after issuing the rename, to decide whether it's genuinely "stale" (left behind) vs cleanly renamed away. Right after the rename call, the old ref can still transiently exist (the rename hasn't finished propagating), so it gets misclassified as stale. By the time the user confirms deletion (after other fix steps have run), GitHub's rename has actually completed and the ref is gone — `DELETE .../git/refs/heads/{branch}` then returns 422 "Reference does not exist", which propagated as an unhandled `GitHubClientError` and crashed the CLI mid-`audit --fix`.

## Changes

- Add `GitHubClient.branch_exists(owner, repo, branch)` (mirrors the existing `file_exists` helper).
- In `_handle_stale_branches` (interactive, single-repo) and `_warn_stale_branches` (`--all` mode), re-check `branch_exists` right before prompting/warning about a "stale" branch. If it's already gone, skip with a short note instead of crashing.
- Keep the actual `delete_branch` call wrapped defensively too, in case of a further late race between the check and the delete.
- Add `tests/test_cli.py` (new file) with direct unit tests of these two helper functions (mocked client, patched `click.confirm` — no `CliRunner`), plus new `branch_exists` tests in `test_github_client.py`.

## Testing

- `uv run pytest` — 143 passed
- `uv run ruff check src/ tests/` — clean
- `uv run ruff format --check src/ tests/` — clean