### PR TITLE
Allow init when origin already points at the target repo

### DIFF
--- a/src/gds_idea_gh_kit/init.py
+++ b/src/gds_idea_gh_kit/init.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from gds_idea_gh_kit.checks.branches import build_ruleset_payload, ruleset_name
 from gds_idea_gh_kit.github_client import GitHubClient, GitHubClientError
 from gds_idea_gh_kit.models import Config
+from gds_idea_gh_kit.repo_info import RepoInfoError, parse_github_remote
 
 # GitHub API uses different permission names for writing vs config:
 #   Config uses: read, write, admin, maintain, triage
@@ -47,8 +48,14 @@ def _run_git(*args: str) -> str:
         raise InitError(f"git {' '.join(args)} failed: {e.stderr.strip()}")
 
 
-def _check_preconditions(repo_name: str, config: Config, repo_type: str) -> None:
-    """Validate preconditions before init. Raises InitError on failure."""
+def _check_preconditions(repo_name: str, config: Config, repo_type: str) -> bool:
+    """Validate preconditions before init.
+
+    Returns True if 'origin' already points at the target repo (e.g. it
+    was created with `gh repo create --source . --push`), meaning the
+    repo-creation and initial-push steps should be skipped. Raises
+    InitError on failure.
+    """
     # Must be inside a git repo
     try:
         _run_git("rev-parse", "--is-inside-work-tree")
@@ -61,16 +68,30 @@ def _check_preconditions(repo_name: str, config: Config, repo_type: str) -> None
     except InitError:
         raise InitError("Git repo has no commits. Run 'idea-app init' first to scaffold the project.")
 
-    # Must not already have a remote
+    # A remote is fine as long as it already points at the target repo
+    # (e.g. `gh repo create --source . --push` was used to create it).
+    # Anything else is a conflict — bail out rather than push over an
+    # unrelated repo.
+    repo_already_created = False
     try:
-        _run_git("remote", "get-url", "origin")
-        raise InitError(
-            "This repo already has a remote 'origin'. Use 'idea-gh audit --fix' to configure an existing repo."
-        )
-    except InitError as e:
-        if "already has a remote" in str(e):
-            raise
-        # No remote is what we want — continue
+        existing_url = _run_git("remote", "get-url", "origin")
+    except InitError:
+        existing_url = None
+
+    if existing_url:
+        try:
+            existing_owner, existing_repo = parse_github_remote(existing_url)
+        except RepoInfoError:
+            existing_owner, existing_repo = None, None
+
+        if existing_owner == config.org and existing_repo == repo_name:
+            repo_already_created = True
+        else:
+            raise InitError(
+                f"This repo already has a remote 'origin' pointing to '{existing_url}', "
+                f"which doesn't match the expected repo '{config.org}/{repo_name}'. "
+                "Use 'idea-gh audit --fix' to configure it, or remove the remote and re-run init."
+            )
 
     # Repo name must match the type's naming pattern
     type_config = config.repo_types[repo_type]
@@ -79,6 +100,8 @@ def _check_preconditions(repo_name: str, config: Config, repo_type: str) -> None
             f"Directory name '{repo_name}' does not match the expected naming "
             f"pattern for {repo_type}: {type_config.naming_pattern}"
         )
+
+    return repo_already_created
 
 
 def init_repo(
@@ -99,26 +122,34 @@ def init_repo(
     type_config = config.repo_types[repo_type]
     default_branch = type_config.default_branch
 
-    _check_preconditions(repo_name, config, repo_type)
+    repo_already_created = _check_preconditions(repo_name, config, repo_type)
 
-    # 1. Create the GitHub repo
-    try:
-        client.create_repo(
-            org,
-            repo_name,
-            visibility=config.default_visibility,
-            auto_init=False,
-        )
-    except GitHubClientError as e:
-        raise InitError(f"Failed to create repo: {e}")
-    steps.append(f"Created repo {org}/{repo_name} ({config.default_visibility})")
+    # 1. Create the GitHub repo (skip if one was already created and
+    # pushed, e.g. via `gh repo create --source . --push`)
+    if repo_already_created:
+        try:
+            client.get_repo(org, repo_name)
+        except GitHubClientError as e:
+            raise InitError(f"Remote 'origin' points at {org}/{repo_name}, but it wasn't found on GitHub: {e}")
+        steps.append(f"Using existing repo {org}/{repo_name}")
+    else:
+        try:
+            client.create_repo(
+                org,
+                repo_name,
+                visibility=config.default_visibility,
+                auto_init=False,
+            )
+        except GitHubClientError as e:
+            raise InitError(f"Failed to create repo: {e}")
+        steps.append(f"Created repo {org}/{repo_name} ({config.default_visibility})")
 
-    # 2. Add remote and push
-    _run_git("remote", "add", "origin", f"git@github.com:{org}/{repo_name}.git")
-    steps.append("Added remote origin")
+        # 2. Add remote and push
+        _run_git("remote", "add", "origin", f"git@github.com:{org}/{repo_name}.git")
+        steps.append("Added remote origin")
 
-    _run_git("push", "-u", "origin", "HEAD:main")
-    steps.append("Pushed to origin/main")
+        _run_git("push", "-u", "origin", "HEAD:main")
+        steps.append("Pushed to origin/main")
 
     # 3. Apply repo settings
     settings = config.repo_settings.model_dump()

--- a/src/gds_idea_gh_kit/repo_info.py
+++ b/src/gds_idea_gh_kit/repo_info.py
@@ -29,10 +29,10 @@ def get_repo_from_remote() -> tuple[str, str]:
         raise RepoInfoError("Could not read git remote 'origin'. Are you inside a git repo with a remote configured?")
 
     url = result.stdout.strip()
-    return _parse_github_remote(url)
+    return parse_github_remote(url)
 
 
-def _parse_github_remote(url: str) -> tuple[str, str]:
+def parse_github_remote(url: str) -> tuple[str, str]:
     """Extract (owner, repo) from a GitHub remote URL.
 
     Supports:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -69,12 +69,17 @@ def _test_config() -> Config:
     )
 
 
-def _mock_git_success(cmd_results: dict[tuple[str, ...], str] | None = None):
-    """Return a mock for _run_git that returns preset values."""
+def _mock_git_success(cmd_results: dict[tuple[str, ...], str] | None = None, remote_url: str | None = None):
+    """Return a mock for _run_git that returns preset values.
+
+    By default there's no 'origin' remote (raises, as git does when
+    none is configured). Pass *remote_url* to simulate a repo that
+    already has an 'origin' remote pointing at that URL.
+    """
     defaults: dict[tuple[str, ...], str] = {
         ("rev-parse", "--is-inside-work-tree"): "true",
         ("rev-parse", "HEAD"): "abc123",
-        ("remote", "get-url", "origin"): "",  # Will raise CalledProcessError
+        ("remote", "get-url", "origin"): remote_url or "",
         ("remote", "add", "origin"): "",
         ("push", "-u", "origin", "HEAD:main"): "",
         ("branch", "-m", "main", "dev"): "",
@@ -87,7 +92,7 @@ def _mock_git_success(cmd_results: dict[tuple[str, ...], str] | None = None):
     def fake_run_git(*args: str) -> str:
         key = tuple(args)
         # Simulate "no remote" by raising for remote get-url
-        if key == ("remote", "get-url", "origin"):
+        if key == ("remote", "get-url", "origin") and not remote_url:
             raise InitError("git remote get-url origin failed: ")
         if key in defaults:
             return defaults[key]
@@ -97,15 +102,26 @@ def _mock_git_success(cmd_results: dict[tuple[str, ...], str] | None = None):
     return fake_run_git
 
 
-def _mock_all_api_calls(httpx_mock: HTTPXMock):
-    """Mock all GitHub API calls for a successful init."""
-    # 1. Create repo
-    httpx_mock.add_response(
-        url=f"{BASE}/orgs/co-cddo/repos",
-        method="POST",
-        json={"name": "gds-idea-app-dashboard", "full_name": "co-cddo/gds-idea-app-dashboard"},
-        status_code=201,
-    )
+def _mock_all_api_calls(httpx_mock: HTTPXMock, repo_already_exists: bool = False):
+    """Mock all GitHub API calls for a successful init.
+
+    If *repo_already_exists*, the repo-creation step is replaced with
+    the GET used to confirm the pre-existing repo is reachable.
+    """
+    if repo_already_exists:
+        httpx_mock.add_response(
+            url=f"{BASE}/repos/co-cddo/gds-idea-app-dashboard",
+            method="GET",
+            json={"name": "gds-idea-app-dashboard", "full_name": "co-cddo/gds-idea-app-dashboard"},
+        )
+    else:
+        # 1. Create repo
+        httpx_mock.add_response(
+            url=f"{BASE}/orgs/co-cddo/repos",
+            method="POST",
+            json={"name": "gds-idea-app-dashboard", "full_name": "co-cddo/gds-idea-app-dashboard"},
+            status_code=201,
+        )
 
     # 2. Update repo settings
     httpx_mock.add_response(
@@ -227,8 +243,8 @@ def test_init_repo_rejects_bad_name(mock_git, httpx_mock: HTTPXMock, gh_client: 
 
 
 @patch("gds_idea_gh_kit.init._run_git")
-def test_init_repo_rejects_existing_remote(mock_git, httpx_mock: HTTPXMock, gh_client: GitHubClient):
-    """Init errors if the repo already has a remote."""
+def test_init_repo_rejects_mismatched_remote(mock_git, httpx_mock: HTTPXMock, gh_client: GitHubClient):
+    """Init errors if the existing remote points at a different repo."""
 
     def fake_git(*args):
         key = tuple(args)
@@ -237,13 +253,47 @@ def test_init_repo_rejects_existing_remote(mock_git, httpx_mock: HTTPXMock, gh_c
         if key == ("rev-parse", "HEAD"):
             return "abc123"
         if key == ("remote", "get-url", "origin"):
-            return "git@github.com:co-cddo/gds-idea-app-dashboard.git"
+            return "git@github.com:some-other-org/some-other-repo.git"
         return ""
 
     mock_git.side_effect = fake_git
 
     config = _test_config()
-    with pytest.raises(InitError, match="already has a remote"):
+    with pytest.raises(InitError, match="doesn't match the expected repo"):
+        init_repo("gds-idea-app-dashboard", config, "cdk-app", gh_client)
+
+
+@patch("gds_idea_gh_kit.init._run_git")
+def test_init_repo_reuses_existing_repo_when_remote_matches(mock_git, httpx_mock: HTTPXMock, gh_client: GitHubClient):
+    """When origin already points at the target repo (e.g. after
+    `gh repo create --source . --push`), init skips create/push and
+    configures the existing repo instead of erroring."""
+    mock_git.side_effect = _mock_git_success(remote_url="git@github.com:co-cddo/gds-idea-app-dashboard.git")
+    _mock_all_api_calls(httpx_mock, repo_already_exists=True)
+
+    config = _test_config()
+    steps = init_repo("gds-idea-app-dashboard", config, "cdk-app", gh_client)
+
+    assert any("Using existing repo" in s for s in steps)
+    assert not any("Created repo" in s for s in steps)
+    assert not any("Added remote" in s for s in steps)
+    assert not any("Pushed" in s for s in steps)
+    assert any("repo settings" in s for s in steps)
+    assert any("main -> dev" in s for s in steps)
+
+
+@patch("gds_idea_gh_kit.init._run_git")
+def test_init_repo_errors_when_remote_exists_but_repo_missing(mock_git, httpx_mock: HTTPXMock, gh_client: GitHubClient):
+    """Origin points at the target repo, but it's not actually on GitHub."""
+    mock_git.side_effect = _mock_git_success(remote_url="git@github.com:co-cddo/gds-idea-app-dashboard.git")
+    httpx_mock.add_response(
+        url=f"{BASE}/repos/co-cddo/gds-idea-app-dashboard",
+        method="GET",
+        status_code=404,
+    )
+
+    config = _test_config()
+    with pytest.raises(InitError, match="wasn't found on GitHub"):
         init_repo("gds-idea-app-dashboard", config, "cdk-app", gh_client)
 
 

--- a/tests/test_repo_info.py
+++ b/tests/test_repo_info.py
@@ -2,33 +2,33 @@
 
 import pytest
 
-from gds_idea_gh_kit.repo_info import RepoInfoError, _parse_github_remote
+from gds_idea_gh_kit.repo_info import RepoInfoError, parse_github_remote
 
 
 def test_parse_ssh_remote():
-    owner, repo = _parse_github_remote("git@github.com:co-cddo/gds-idea-app-foo.git")
+    owner, repo = parse_github_remote("git@github.com:co-cddo/gds-idea-app-foo.git")
     assert owner == "co-cddo"
     assert repo == "gds-idea-app-foo"
 
 
 def test_parse_ssh_remote_no_git_suffix():
-    owner, repo = _parse_github_remote("git@github.com:co-cddo/gds-idea-app-foo")
+    owner, repo = parse_github_remote("git@github.com:co-cddo/gds-idea-app-foo")
     assert owner == "co-cddo"
     assert repo == "gds-idea-app-foo"
 
 
 def test_parse_https_remote():
-    owner, repo = _parse_github_remote("https://github.com/co-cddo/gds-idea-app-foo.git")
+    owner, repo = parse_github_remote("https://github.com/co-cddo/gds-idea-app-foo.git")
     assert owner == "co-cddo"
     assert repo == "gds-idea-app-foo"
 
 
 def test_parse_https_remote_no_git_suffix():
-    owner, repo = _parse_github_remote("https://github.com/co-cddo/gds-idea-app-foo")
+    owner, repo = parse_github_remote("https://github.com/co-cddo/gds-idea-app-foo")
     assert owner == "co-cddo"
     assert repo == "gds-idea-app-foo"
 
 
 def test_parse_non_github_remote():
     with pytest.raises(RepoInfoError, match="Could not parse"):
-        _parse_github_remote("git@gitlab.com:co-cddo/foo.git")
+        parse_github_remote("git@gitlab.com:co-cddo/foo.git")


### PR DESCRIPTION
## Summary

Fixes #36.

`idea-gh init` hard-failed whenever a local git remote `origin` existed at all, even when it correctly pointed at the repo about to be initialised. This is exactly the state left behind by the standard `gh repo create --source . --push` workflow (create the GitHub repo, add the remote, and push, all in one step) — a completely reasonable way to set up a repo before running `idea-gh init`.

## Changes

- `repo_info.parse_github_remote` is now public (was `_parse_github_remote`) so `init.py` can reuse it to parse the existing remote URL.
- `init._check_preconditions` now returns whether `origin` already points at `config.org/repo_name`. If it does, `init_repo` skips the repo-creation and initial-push steps (after confirming the repo is actually reachable on GitHub via `get_repo`) and proceeds straight to configuring settings, branch protection, teams, rulesets, security, and labels as normal.
- A remote pointing at anything else is still rejected, now with a clearer error showing what it actually points to vs. what was expected.
- Updated `test_init_repo_rejects_existing_remote` → `test_init_repo_rejects_mismatched_remote` (the old test asserted the exact buggy behaviour — a matching remote should now succeed, not error) and added new tests for the matching-remote happy path and the "remote matches but repo missing on GitHub" edge case.

## Testing

- `uv run pytest` — 145 passed
- `uv run ruff check src/ tests/` / `ruff format --check` — clean
- Manually verified live against the real GitHub API (not just mocks) in a throwaway local repo:
  - mismatched remote → clear rejection error
  - matching remote to a nonexistent repo → clear "wasn't found on GitHub" error