### PR TITLE
Offer to migrate local clone after a default branch rename

### DIFF
--- a/src/gds_idea_gh_kit/audit.py
+++ b/src/gds_idea_gh_kit/audit.py
@@ -156,9 +156,10 @@ def fix_repo(
 
     # Branches (default branch + rulesets)
     try:
-        changes, stale = branches.fix(owner, repo, type_config, client)
+        changes, stale, branch_rename = branches.fix(owner, repo, type_config, client)
         fix_report.changes.extend(f"branches: {c}" for c in changes)
         fix_report.stale_branches.extend(stale)
+        fix_report.branch_rename = branch_rename
     except Exception as e:
         fix_report.errors.append(f"branches fix failed: {e}")
 

--- a/src/gds_idea_gh_kit/checks/branches.py
+++ b/src/gds_idea_gh_kit/checks/branches.py
@@ -292,16 +292,20 @@ def _audit_ruleset(
 
 def fix(
     owner: str, repo: str, type_config: RepoTypeConfig, client: GitHubClient
-) -> tuple[list[str], list[StaleBranch]]:
+) -> tuple[list[str], list[StaleBranch], tuple[str, str] | None]:
     """Apply default branch and ruleset fixes.
 
-    Returns a tuple of (changes, stale_branches).  *stale_branches*
-    lists any branches that were superseded by the new default but
-    could not be renamed away (because the target already existed).
-    The caller is responsible for prompting the user about deletion.
+    Returns a tuple of (changes, stale_branches, branch_rename).
+    *stale_branches* lists any branches that were superseded by the new
+    default but could not be renamed away (because the target already
+    existed) — the caller is responsible for prompting the user about
+    deletion. *branch_rename* is (old_default, new_default) if the
+    default branch was renamed, else None — the caller can use this to
+    offer to migrate a local clone.
     """
     changes: list[str] = []
     stale_branches: list[StaleBranch] = []
+    branch_rename: tuple[str, str] | None = None
     repo_data = client.get_repo(owner, repo)
     org = client.org or owner
     old_default = repo_data["default_branch"]
@@ -311,6 +315,7 @@ def fix(
     if old_default != new_default:
         client.rename_default_branch(owner, repo, new_default)
         changes.append(f"Default branch: {old_default} -> {new_default}")
+        branch_rename = (old_default, new_default)
 
         # Check if the old branch still exists (rename vs set-default).
         # If rename succeeded, the old branch is gone.  If we fell back
@@ -350,7 +355,7 @@ def fix(
             client.create_ruleset(owner, repo, payload)
             changes.append(f"Created ruleset '{name}'")
 
-    return changes, stale_branches
+    return changes, stale_branches, branch_rename
 
 
 def build_ruleset_payload(

--- a/src/gds_idea_gh_kit/cli.py
+++ b/src/gds_idea_gh_kit/cli.py
@@ -119,6 +119,7 @@ def audit(ctx: click.Context, repo_type: str | None, audit_all: bool, apply_fix:
                 fix_result = fix_repo(owner, repo, config, client, report.repo_type)
                 _render_fix_result(fix_result)
                 _handle_stale_branches(fix_result, owner, repo, client)
+                _handle_branch_rename_migration(fix_result)
 
                 # Re-audit to show updated state
                 click.echo()
@@ -201,6 +202,60 @@ def _warn_stale_branches(fix_result, owner, repo, client):
             click.echo(
                 f"  ! Branch '{stale.branch}' has {stale.ahead_by} unmerged commit(s). Review and delete manually."
             )
+
+
+def _run_git_step(*args: str) -> tuple[bool, str]:
+    """Run a git command for local branch migration. Never raises.
+
+    Returns (success, output_or_error).
+    """
+    import subprocess
+
+    try:
+        result = subprocess.run(["git", *args], capture_output=True, text=True, timeout=30)
+    except (OSError, subprocess.TimeoutExpired) as e:
+        return False, str(e)
+
+    if result.returncode != 0:
+        return False, result.stderr.strip() or result.stdout.strip()
+    return True, result.stdout.strip()
+
+
+def _handle_branch_rename_migration(fix_result):
+    """Offer to update the local clone after the default branch was renamed."""
+    if fix_result.branch_rename is None:
+        return
+
+    old_default, new_default = fix_result.branch_rename
+    manual_hint = (
+        f"git branch -m {old_default} {new_default} && git fetch origin && "
+        f"git branch -u origin/{new_default} {new_default} && git remote set-head origin -a"
+    )
+
+    click.echo()
+    click.echo(f"The default branch was renamed from '{old_default}' to '{new_default}'.")
+    if not click.confirm(f"Update this local clone to track '{new_default}'?", default=False):
+        click.echo(f"  Leaving local clone on '{old_default}'. To migrate manually later, run:")
+        click.echo(f"    {manual_hint}")
+        return
+
+    steps = [
+        ("branch", "-m", old_default, new_default),
+        ("fetch", "origin"),
+        ("branch", "-u", f"origin/{new_default}", new_default),
+        ("remote", "set-head", "origin", "-a"),
+    ]
+    for args in steps:
+        ok, output = _run_git_step(*args)
+        command = "git " + " ".join(args)
+        if ok:
+            click.echo(f"  \u2713 {command}")
+        else:
+            click.echo(f"  \u2717 {command} failed: {output}")
+            click.echo(f"  Stopping local migration. To finish manually, run:\n    {manual_hint}")
+            return
+
+    click.echo(f"  Local clone now tracks '{new_default}'.")
 
 
 def _audit_all_repos(

--- a/src/gds_idea_gh_kit/models.py
+++ b/src/gds_idea_gh_kit/models.py
@@ -83,6 +83,8 @@ class FixReport(BaseModel):
     changes: list[str] = Field(default_factory=list)
     errors: list[str] = Field(default_factory=list)
     stale_branches: list[StaleBranch] = Field(default_factory=list)
+    branch_rename: tuple[str, str] | None = None
+    """(old_default, new_default) if the default branch was renamed, else None."""
 
 
 # --- Config models loaded from YAML ---

--- a/tests/test_checks/test_branches.py
+++ b/tests/test_checks/test_branches.py
@@ -360,10 +360,11 @@ def test_fix_rename_succeeds_no_stale_branch(httpx_mock: HTTPXMock, gh_client: G
     )
 
     type_config = _type_config_with_dev_default()
-    changes, stale_branches = branches.fix("co-cddo", "my-repo", type_config, gh_client)
+    changes, stale_branches, branch_rename = branches.fix("co-cddo", "my-repo", type_config, gh_client)
 
     assert any("main -> dev" in c for c in changes)
     assert len(stale_branches) == 0
+    assert branch_rename == ("main", "dev")
 
 
 def test_fix_fallback_reports_stale_merged_branch(httpx_mock: HTTPXMock, gh_client: GitHubClient):
@@ -423,13 +424,14 @@ def test_fix_fallback_reports_stale_merged_branch(httpx_mock: HTTPXMock, gh_clie
     )
 
     type_config = _type_config_with_dev_default()
-    changes, stale_branches = branches.fix("co-cddo", "my-repo", type_config, gh_client)
+    changes, stale_branches, branch_rename = branches.fix("co-cddo", "my-repo", type_config, gh_client)
 
     assert any("main -> dev" in c for c in changes)
     assert len(stale_branches) == 1
     assert stale_branches[0].branch == "main"
     assert stale_branches[0].default_branch == "dev"
     assert stale_branches[0].is_merged is True
+    assert branch_rename == ("main", "dev")
 
 
 def test_fix_fallback_reports_stale_unmerged_branch(httpx_mock: HTTPXMock, gh_client: GitHubClient):
@@ -489,12 +491,13 @@ def test_fix_fallback_reports_stale_unmerged_branch(httpx_mock: HTTPXMock, gh_cl
     )
 
     type_config = _type_config_with_dev_default()
-    changes, stale_branches = branches.fix("co-cddo", "my-repo", type_config, gh_client)
+    changes, stale_branches, branch_rename = branches.fix("co-cddo", "my-repo", type_config, gh_client)
 
     assert len(stale_branches) == 1
     assert stale_branches[0].branch == "main"
     assert stale_branches[0].ahead_by == 3
     assert stale_branches[0].is_merged is False
+    assert branch_rename == ("main", "dev")
 
 
 def test_fix_no_stale_when_default_already_correct(httpx_mock: HTTPXMock, gh_client: GitHubClient):
@@ -523,9 +526,10 @@ def test_fix_no_stale_when_default_already_correct(httpx_mock: HTTPXMock, gh_cli
     )
 
     type_config = _type_config_with_dev_default()
-    changes, stale_branches = branches.fix("co-cddo", "my-repo", type_config, gh_client)
+    changes, stale_branches, branch_rename = branches.fix("co-cddo", "my-repo", type_config, gh_client)
 
     assert len(stale_branches) == 0
+    assert branch_rename is None
 
 
 # --- Allowed merge methods ---

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
-from gds_idea_gh_kit.cli import _handle_stale_branches, _warn_stale_branches
+from gds_idea_gh_kit.cli import (
+    _handle_branch_rename_migration,
+    _handle_stale_branches,
+    _run_git_step,
+    _warn_stale_branches,
+)
 from gds_idea_gh_kit.github_client import GitHubClientError
 from gds_idea_gh_kit.models import FixReport, StaleBranch
 
@@ -15,6 +20,10 @@ def _fix_result_with_stale(branch: str = "main", default_branch: str = "dev", ah
         repo_type="cdk-app",
         stale_branches=[StaleBranch(branch=branch, default_branch=default_branch, ahead_by=ahead_by)],
     )
+
+
+def _fix_result_with_rename(old: str = "main", new: str = "dev") -> FixReport:
+    return FixReport(repo_name="my-repo", repo_type="cdk-app", branch_rename=(old, new))
 
 
 # --- _handle_stale_branches ---
@@ -111,3 +120,117 @@ def test_warn_stale_branches_warns_for_existing_merged_branch(capsys):
     out = capsys.readouterr().out
     assert "fully merged" in out
     assert "main" in out
+
+
+# --- _run_git_step ---
+
+
+class _FakeCompletedProcess:
+    def __init__(self, returncode: int = 0, stdout: str = "", stderr: str = ""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def test_run_git_step_success(monkeypatch):
+    monkeypatch.setattr("subprocess.run", lambda *a, **k: _FakeCompletedProcess(stdout="ok\n"))
+
+    ok, output = _run_git_step("fetch", "origin")
+
+    assert ok is True
+    assert output == "ok"
+
+
+def test_run_git_step_failure(monkeypatch):
+    monkeypatch.setattr("subprocess.run", lambda *a, **k: _FakeCompletedProcess(returncode=1, stderr="fatal: error\n"))
+
+    ok, output = _run_git_step("branch", "-m", "main", "dev")
+
+    assert ok is False
+    assert "fatal: error" in output
+
+
+def test_run_git_step_never_raises_when_git_missing(monkeypatch):
+    def fake_run(*args, **kwargs):
+        raise FileNotFoundError("git not found")
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    ok, output = _run_git_step("fetch", "origin")  # should not raise
+
+    assert ok is False
+
+
+# --- _handle_branch_rename_migration ---
+
+
+def test_handle_branch_rename_migration_noop_when_no_rename(capsys):
+    fix_result = FixReport(repo_name="my-repo", repo_type="cdk-app")
+
+    _handle_branch_rename_migration(fix_result)
+
+    assert capsys.readouterr().out == ""
+
+
+def test_handle_branch_rename_migration_asks_before_doing_anything(monkeypatch, capsys):
+    """The migration is always asked for, never automatic."""
+    confirm_called = False
+
+    def fake_confirm(*args, **kwargs):
+        nonlocal confirm_called
+        confirm_called = True
+        return False
+
+    monkeypatch.setattr("click.confirm", fake_confirm)
+    run_calls = []
+    monkeypatch.setattr("subprocess.run", lambda *a, **k: run_calls.append(a))
+
+    fix_result = _fix_result_with_rename()
+    _handle_branch_rename_migration(fix_result)
+
+    assert confirm_called is True
+    assert run_calls == []  # declined, so no git commands were run
+    out = capsys.readouterr().out
+    assert "Leaving local clone on 'main'" in out
+    assert "git branch -m main dev" in out
+
+
+def test_handle_branch_rename_migration_runs_all_steps_when_confirmed(monkeypatch):
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return _FakeCompletedProcess()
+
+    monkeypatch.setattr("click.confirm", lambda *a, **k: True)
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    fix_result = _fix_result_with_rename()
+    _handle_branch_rename_migration(fix_result)
+
+    assert calls == [
+        ["git", "branch", "-m", "main", "dev"],
+        ["git", "fetch", "origin"],
+        ["git", "branch", "-u", "origin/dev", "dev"],
+        ["git", "remote", "set-head", "origin", "-a"],
+    ]
+
+
+def test_handle_branch_rename_migration_stops_on_first_failure(monkeypatch, capsys):
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        # First step fails; later steps (if reached) would succeed.
+        return _FakeCompletedProcess(returncode=1 if len(calls) == 1 else 0, stderr="boom")
+
+    monkeypatch.setattr("click.confirm", lambda *a, **k: True)
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    fix_result = _fix_result_with_rename()
+    _handle_branch_rename_migration(fix_result)  # should not raise
+
+    assert len(calls) == 1
+    out = capsys.readouterr().out
+    assert "failed" in out
+    assert "Stopping local migration" in out


### PR DESCRIPTION
## Summary

Fixes #16.

When `idea-gh audit --fix` renames a repo's default branch (e.g. `main` -> `dev`), GitHub's web UI shows the git commands needed to update a local clone, but the CLI never offered to run them — the user had to copy/paste them manually.

As agreed, this is **always asked, never automatic** — it prompts with `click.confirm(default=False)` before touching the local clone.

## Changes

- `FixReport.branch_rename: tuple[str, str] | None` — new field capturing (old_default, new_default) when the default branch changes.
- `checks/branches.py::fix()` now returns `(changes, stale_branches, branch_rename)` instead of a 2-tuple; `audit.py::fix_repo()` propagates it into `FixReport.branch_rename`. Updated the 4 existing test call-sites in `test_branches.py`.
- New `_handle_branch_rename_migration(fix_result)` in `cli.py`, wired into the single-repo `audit --fix` path only (not `--all`, since the current directory only reliably corresponds to one repo there). If a rename happened, it prompts:
  ```
  The default branch was renamed from 'main' to 'dev'.
  Update this local clone to track 'dev'? [y/N]:
  ```
  If confirmed, it runs:
  ```
  git branch -m main dev
  git fetch origin
  git branch -u origin/dev dev
  git remote set-head origin -a
  ```
  via a non-throwing helper (`_run_git_step`) — each step is run defensively; if one fails, it stops and prints the remaining commands to run manually rather than failing the whole `--fix` run. Declining leaves the local clone untouched and prints the same commands for later.
- Unit tests for `_run_git_step` and `_handle_branch_rename_migration` (mocked `subprocess.run`, patched `click.confirm`).

## Testing

- `uv run pytest` — 152 passed
- `uv run ruff check src/ tests/` / `ruff format --check` — clean
- Manually verified live (not just mocks): set up a local clone + local bare "origin" repo simulating a post-rename remote state (local `main`, remote `dev` as new default with stale `origin/main`), then ran the actual helper function:
  - Confirming `y` correctly renamed the local branch, fetched, set upstream to `origin/dev`, and updated `origin/HEAD`.
  - Declining left the local clone on `main`, untouched, and printed the manual commands.